### PR TITLE
Migrate to Bevy 0.18

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,7 @@ information = { path = "crates/information" }
 matter = { path = "crates/matter" }
 utils = { path = "crates/utils" }
 
-bevy = { version = "0.17", features = ["dynamic_linking"] }
+bevy = { version = "0.18", features = ["dynamic_linking"] }
 
 glam = "0.29.2"
 

--- a/crates/energy/Cargo.toml
+++ b/crates/energy/Cargo.toml
@@ -5,5 +5,5 @@ edition = "2024"
 description = "Core systems governing how energy manifests, transforms and flows."
 
 [dependencies]
-bevy = "0.17"
+bevy = "0.18"
 utils = { path = "../utils" }

--- a/crates/forces/Cargo.toml
+++ b/crates/forces/Cargo.toml
@@ -5,4 +5,4 @@ edition = "2024"
 description = "Fundamental interaction mechanisms that create relationships between entities and drive dynamic behaviors across scales."
 
 [dependencies]
-bevy = "0.17"
+bevy = "0.18"

--- a/crates/information/Cargo.toml
+++ b/crates/information/Cargo.toml
@@ -6,7 +6,7 @@ description = "Systems handling pattern emergence, complexity formation, and the
 
 [dependencies]
 
-bevy = "0.17"
+bevy = "0.18"
 
 
 

--- a/crates/lp_tree.txt
+++ b/crates/lp_tree.txt
@@ -1,0 +1,172 @@
+Folder PATH listing for volume Acer
+Volume serial number is 407F-56DF
+C:.
+|   lp_tree.txt
+|   
++---energy
+|   |   Cargo.toml
+|   |   README.md
+|   |   
+|   \---src
+|       |   conservation.rs
+|       |   lib.rs
+|       |   
+|       +---electromagnetism
+|       |       fields.rs
+|       |       interactions.rs
+|       |       mod.rs
+|       |       
+|       +---thermodynamics
+|       |       entropy.rs
+|       |       equilibrium.rs
+|       |       mod.rs
+|       |       thermal.rs
+|       |       
+|       \---waves
+|               mod.rs
+|               oscillation.rs
+|               propagation.rs
+|               superposition.rs
+|               wave_equation.rs
+|               
++---forces
+|   |   Cargo.toml
+|   |   README.md
+|   |   
+|   \---src
+|       |   lib.rs
+|       |   
+|       \---core
+|               gravity.rs
+|               mod.rs
+|               newton_laws.rs
+|               
++---information
+|   |   Cargo.toml
+|   |   README.md
+|   |   
+|   \---src
+|       |   lib.rs
+|       |   
+|       +---fractals
+|       |       core.rs
+|       |       data_loader.rs
+|       |       fractals.json
+|       |       generator.rs
+|       |       grammar.rs
+|       |       interpreter.rs
+|       |       mod.rs
+|       |       renderer.rs
+|       |       
+|       \---measures
+|           |   divergence.rs
+|           |   mod.rs
+|           |   shannon.rs
+|           |   
+|           \---mutual
+|                   calculation.rs
+|                   mod.rs
+|                   
++---matter
+|   |   Cargo.toml
+|   |   README.md
+|   |   
+|   \---src
+|       |   lib.rs
+|       |   mod.rs
+|       |   
+|       \---states
+|           |   mod.rs
+|           |   
+|           +---fluids
+|           |       mod.rs
+|           |       solver.rs
+|           |       
+|           +---gases
+|           |       mod.rs
+|           |       
+|           +---plasma
+|           |       mod.rs
+|           |       
+|           \---solids
+|                   mod.rs
+|                   
++---systems
+|   |   Cargo.toml
+|   |   README.md
+|   |   
+|   +---acoustics
+|   |   |   Cargo.toml
+|   |   |   
+|   |   \---src
+|   |           lib.rs
+|   |           
+|   +---ai
+|   |   |   Cargo.toml
+|   |   |   README.md
+|   |   |   
+|   |   \---src
+|   |       |   lib.rs
+|   |       |   
+|   |       +---arbiter
+|   |       |       mod.rs
+|   |       |       
+|   |       +---drives
+|   |       |       mod.rs
+|   |       |       needs.rs
+|   |       |       
+|   |       +---memory
+|   |       |       mod.rs
+|   |       |       types.rs
+|   |       |       
+|   |       +---personality
+|   |       |       mod.rs
+|   |       |       traits.rs
+|   |       |       
+|   |       +---relationships
+|   |       |       mod.rs
+|   |       |       social.rs
+|   |       |       
+|   |       \---trackers
+|   |               electric_tracker.rs
+|   |               entity_tracker.rs
+|   |               mod.rs
+|   |               needs_tracker.rs
+|   |               perception_tracker.rs
+|   |               prey_tracker.rs
+|   |               thermal_tracker.rs
+|   |               threat_tracker.rs
+|   |               
+|   +---mpm
+|   |   |   Cargo.toml
+|   |   |   
+|   |   \---src
+|   |           grid.rs
+|   |           lib.rs
+|   |           particle.rs
+|   |           solver.rs
+|   |           transfer.rs
+|   |           
+|   +---save_system
+|   |   |   Cargo.toml
+|   |   |   
+|   |   \---src
+|   |           lib.rs
+|   |           save_system.rs
+|   |           versioning.rs
+|   |           
+|   \---src
+|           lib.rs
+|           
+\---utils
+    |   Cargo.toml
+    |   README.md
+    |   
+    \---src
+        |   lib.rs
+        |   pool.rs
+        |   
+        \---spatial
+                grid.rs
+                mod.rs
+                

--- a/crates/matter/Cargo.toml
+++ b/crates/matter/Cargo.toml
@@ -5,4 +5,4 @@ edition = "2024"
 description = "Physical substance modeling from fundamental particles to complex materials, defining how tangible elements behave and interact."
 
 [dependencies]
-bevy = "0.17"
+bevy = "0.18"

--- a/crates/systems/Cargo.toml
+++ b/crates/systems/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2024"
 description = "Core simulation infrastructure components that manage and support the virtual universe rather than represent parts of it."
 
 [dependencies]
-bevy = "0.17"
+bevy = "0.18"
 save_system = { path = "./save_system" }
 mpm = { path = "./mpm" }
 acoustics = { path = "./acoustics" }

--- a/crates/systems/acoustics/Cargo.toml
+++ b/crates/systems/acoustics/Cargo.toml
@@ -5,4 +5,4 @@ edition = "2024"
 description = "Sound generation, playback, and spatial processing system for ambient and interactive audio experiences."
 
 [dependencies]
-bevy = "0.17"
+bevy = "0.18"

--- a/crates/systems/ai/Cargo.toml
+++ b/crates/systems/ai/Cargo.toml
@@ -8,7 +8,7 @@ description = "Utility-based AI framework for life form simulation with modular 
 doctest = false
 
 [dependencies]
-bevy = "0.17"
+bevy = "0.18"
 rand = "0.9"
 energy = { path = "../../energy" }
 

--- a/crates/systems/mpm/Cargo.toml
+++ b/crates/systems/mpm/Cargo.toml
@@ -5,4 +5,4 @@ edition = "2024"
 description = "Material Point Method implementation for simulating continuous materials"
 
 [dependencies]
-bevy = "0.17"
+bevy = "0.18"

--- a/crates/systems/save_system/Cargo.toml
+++ b/crates/systems/save_system/Cargo.toml
@@ -7,5 +7,5 @@ description = "Framework for preserving and restoring simulation states across s
 [dependencies]
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-bevy = "0.17"
+bevy = "0.18"
 platform-dirs = "0.3"

--- a/crates/utils/Cargo.toml
+++ b/crates/utils/Cargo.toml
@@ -5,4 +5,4 @@ edition = "2024"
 description = "Shared utility structures and algorithms for the LP ecosystem."
 
 [dependencies]
-bevy = "0.17"
+bevy = "0.18"

--- a/pre-migration-deps.txt
+++ b/pre-migration-deps.txt
@@ -1,0 +1,1236 @@
+LP v0.1.0 (C:\Users\mathi\Documents\GitHub\LP)
+├── bevy v0.17.2
+│   ├── bevy_dylib v0.17.2
+│   │   └── bevy_internal v0.17.2
+│   │       ├── bevy_a11y v0.17.2
+│   │       │   ├── accesskit v0.21.1
+│   │       │   ├── bevy_app v0.17.2
+│   │       │   │   ├── bevy_derive v0.17.2 (proc-macro)
+│   │       │   │   │   ├── bevy_macro_utils v0.17.2
+│   │       │   │   │   │   ├── parking_lot v0.12.3
+│   │       │   │   │   │   │   ├── lock_api v0.4.12
+│   │       │   │   │   │   │   │   └── scopeguard v1.2.0
+│   │       │   │   │   │   │   │   [build-dependencies]
+│   │       │   │   │   │   │   │   └── autocfg v1.4.0
+│   │       │   │   │   │   │   └── parking_lot_core v0.9.10
+│   │       │   │   │   │   │       ├── cfg-if v1.0.0
+│   │       │   │   │   │   │       ├── smallvec v1.15.0
+│   │       │   │   │   │   │       └── windows-targets v0.52.6
+│   │       │   │   │   │   │           └── windows_x86_64_msvc v0.52.6
+│   │       │   │   │   │   ├── proc-macro2 v1.0.94
+│   │       │   │   │   │   │   └── unicode-ident v1.0.18
+│   │       │   │   │   │   ├── quote v1.0.40
+│   │       │   │   │   │   │   └── proc-macro2 v1.0.94 (*)
+│   │       │   │   │   │   ├── syn v2.0.100
+│   │       │   │   │   │   │   ├── proc-macro2 v1.0.94 (*)
+│   │       │   │   │   │   │   ├── quote v1.0.40 (*)
+│   │       │   │   │   │   │   └── unicode-ident v1.0.18
+│   │       │   │   │   │   └── toml_edit v0.23.7
+│   │       │   │   │   │       ├── indexmap v2.11.4
+│   │       │   │   │   │       │   ├── equivalent v1.0.2
+│   │       │   │   │   │       │   └── hashbrown v0.16.0
+│   │       │   │   │   │       ├── toml_datetime v0.7.3
+│   │       │   │   │   │       ├── toml_parser v1.0.4
+│   │       │   │   │   │       │   └── winnow v0.7.13
+│   │       │   │   │   │       └── winnow v0.7.13
+│   │       │   │   │   ├── quote v1.0.40 (*)
+│   │       │   │   │   └── syn v2.0.100 (*)
+│   │       │   │   ├── bevy_ecs v0.17.2
+│   │       │   │   │   ├── arrayvec v0.7.6
+│   │       │   │   │   ├── bevy_ecs_macros v0.17.2 (proc-macro)
+│   │       │   │   │   │   ├── bevy_macro_utils v0.17.2 (*)
+│   │       │   │   │   │   ├── proc-macro2 v1.0.94 (*)
+│   │       │   │   │   │   ├── quote v1.0.40 (*)
+│   │       │   │   │   │   └── syn v2.0.100 (*)
+│   │       │   │   │   ├── bevy_platform v0.17.2
+│   │       │   │   │   │   ├── foldhash v0.2.0
+│   │       │   │   │   │   ├── hashbrown v0.16.0
+│   │       │   │   │   │   │   ├── equivalent v1.0.2
+│   │       │   │   │   │   │   └── serde v1.0.228
+│   │       │   │   │   │   │       ├── serde_core v1.0.228
+│   │       │   │   │   │   │       └── serde_derive v1.0.228 (proc-macro)
+│   │       │   │   │   │   │           ├── proc-macro2 v1.0.94 (*)
+│   │       │   │   │   │   │           ├── quote v1.0.40 (*)
+│   │       │   │   │   │   │           └── syn v2.0.100 (*)
+│   │       │   │   │   │   ├── serde v1.0.228 (*)
+│   │       │   │   │   │   └── spin v0.10.0
+│   │       │   │   │   ├── bevy_ptr v0.17.2
+│   │       │   │   │   ├── bevy_reflect v0.17.2
+│   │       │   │   │   │   ├── assert_type_match v0.1.1 (proc-macro)
+│   │       │   │   │   │   │   ├── proc-macro2 v1.0.94 (*)
+│   │       │   │   │   │   │   ├── quote v1.0.40 (*)
+│   │       │   │   │   │   │   └── syn v2.0.100 (*)
+│   │       │   │   │   │   ├── bevy_platform v0.17.2 (*)
+│   │       │   │   │   │   ├── bevy_ptr v0.17.2
+│   │       │   │   │   │   ├── bevy_reflect_derive v0.17.2 (proc-macro)
+│   │       │   │   │   │   │   ├── bevy_macro_utils v0.17.2 (*)
+│   │       │   │   │   │   │   ├── indexmap v2.11.4 (*)
+│   │       │   │   │   │   │   ├── proc-macro2 v1.0.94 (*)
+│   │       │   │   │   │   │   ├── quote v1.0.40 (*)
+│   │       │   │   │   │   │   └── syn v2.0.100 (*)
+│   │       │   │   │   │   ├── bevy_utils v0.17.2
+│   │       │   │   │   │   │   ├── bevy_platform v0.17.2 (*)
+│   │       │   │   │   │   │   ├── disqualified v1.0.0
+│   │       │   │   │   │   │   └── thread_local v1.1.8
+│   │       │   │   │   │   │       ├── cfg-if v1.0.0
+│   │       │   │   │   │   │       └── once_cell v1.21.3
+│   │       │   │   │   │   ├── derive_more v2.0.1
+│   │       │   │   │   │   │   └── derive_more-impl v2.0.1 (proc-macro)
+│   │       │   │   │   │   │       ├── proc-macro2 v1.0.94 (*)
+│   │       │   │   │   │   │       ├── quote v1.0.40 (*)
+│   │       │   │   │   │   │       ├── syn v2.0.100 (*)
+│   │       │   │   │   │   │       └── unicode-xid v0.2.6
+│   │       │   │   │   │   ├── disqualified v1.0.0
+│   │       │   │   │   │   ├── downcast-rs v2.0.2
+│   │       │   │   │   │   ├── erased-serde v0.4.6
+│   │       │   │   │   │   │   ├── serde v1.0.228 (*)
+│   │       │   │   │   │   │   └── typeid v1.0.3
+│   │       │   │   │   │   ├── foldhash v0.2.0
+│   │       │   │   │   │   ├── glam v0.30.8
+│   │       │   │   │   │   │   ├── bytemuck v1.22.0
+│   │       │   │   │   │   │   │   └── bytemuck_derive v1.9.3 (proc-macro)
+│   │       │   │   │   │   │   │       ├── proc-macro2 v1.0.94 (*)
+│   │       │   │   │   │   │   │       ├── quote v1.0.40 (*)
+│   │       │   │   │   │   │   │       └── syn v2.0.100 (*)
+│   │       │   │   │   │   │   ├── libm v0.2.11
+│   │       │   │   │   │   │   ├── rand v0.9.0
+│   │       │   │   │   │   │   │   ├── rand_chacha v0.9.0
+│   │       │   │   │   │   │   │   │   ├── ppv-lite86 v0.2.21
+│   │       │   │   │   │   │   │   │   │   └── zerocopy v0.8.27
+│   │       │   │   │   │   │   │   │   │       └── zerocopy-derive v0.8.27 (proc-macro)
+│   │       │   │   │   │   │   │   │   │           ├── proc-macro2 v1.0.94 (*)
+│   │       │   │   │   │   │   │   │   │           ├── quote v1.0.40 (*)
+│   │       │   │   │   │   │   │   │   │           └── syn v2.0.100 (*)
+│   │       │   │   │   │   │   │   │   └── rand_core v0.9.3
+│   │       │   │   │   │   │   │   │       └── getrandom v0.3.2
+│   │       │   │   │   │   │   │   │           └── cfg-if v1.0.0
+│   │       │   │   │   │   │   │   ├── rand_core v0.9.3 (*)
+│   │       │   │   │   │   │   │   └── zerocopy v0.8.27 (*)
+│   │       │   │   │   │   │   └── serde_core v1.0.228
+│   │       │   │   │   │   ├── inventory v0.3.21
+│   │       │   │   │   │   ├── petgraph v0.8.3
+│   │       │   │   │   │   │   ├── fixedbitset v0.5.7
+│   │       │   │   │   │   │   ├── hashbrown v0.15.2
+│   │       │   │   │   │   │   │   └── foldhash v0.1.5
+│   │       │   │   │   │   │   ├── indexmap v2.11.4
+│   │       │   │   │   │   │   │   ├── equivalent v1.0.2
+│   │       │   │   │   │   │   │   ├── hashbrown v0.16.0 (*)
+│   │       │   │   │   │   │   │   └── serde_core v1.0.228
+│   │       │   │   │   │   │   ├── serde v1.0.228 (*)
+│   │       │   │   │   │   │   └── serde_derive v1.0.228 (proc-macro) (*)
+│   │       │   │   │   │   ├── serde v1.0.228 (*)
+│   │       │   │   │   │   ├── smallvec v1.15.0
+│   │       │   │   │   │   ├── smol_str v0.2.2
+│   │       │   │   │   │   │   └── serde v1.0.228 (*)
+│   │       │   │   │   │   ├── thiserror v2.0.17
+│   │       │   │   │   │   │   └── thiserror-impl v2.0.17 (proc-macro)
+│   │       │   │   │   │   │       ├── proc-macro2 v1.0.94 (*)
+│   │       │   │   │   │   │       ├── quote v1.0.40 (*)
+│   │       │   │   │   │   │       └── syn v2.0.100 (*)
+│   │       │   │   │   │   ├── uuid v1.18.1
+│   │       │   │   │   │   │   ├── getrandom v0.3.2 (*)
+│   │       │   │   │   │   │   └── serde v1.0.228 (*)
+│   │       │   │   │   │   └── variadics_please v1.1.0 (proc-macro)
+│   │       │   │   │   │       ├── proc-macro2 v1.0.94 (*)
+│   │       │   │   │   │       ├── quote v1.0.40 (*)
+│   │       │   │   │   │       └── syn v2.0.100 (*)
+│   │       │   │   │   ├── bevy_tasks v0.17.2
+│   │       │   │   │   │   ├── async-channel v2.3.1
+│   │       │   │   │   │   │   ├── concurrent-queue v2.5.0
+│   │       │   │   │   │   │   │   └── crossbeam-utils v0.8.21
+│   │       │   │   │   │   │   ├── event-listener-strategy v0.5.4
+│   │       │   │   │   │   │   │   ├── event-listener v5.4.0
+│   │       │   │   │   │   │   │   │   ├── concurrent-queue v2.5.0 (*)
+│   │       │   │   │   │   │   │   │   ├── parking v2.2.1
+│   │       │   │   │   │   │   │   │   └── pin-project-lite v0.2.16
+│   │       │   │   │   │   │   │   └── pin-project-lite v0.2.16
+│   │       │   │   │   │   │   ├── futures-core v0.3.31
+│   │       │   │   │   │   │   └── pin-project-lite v0.2.16
+│   │       │   │   │   │   ├── async-executor v1.13.1
+│   │       │   │   │   │   │   ├── async-task v4.7.1
+│   │       │   │   │   │   │   ├── concurrent-queue v2.5.0 (*)
+│   │       │   │   │   │   │   ├── fastrand v2.3.0
+│   │       │   │   │   │   │   ├── futures-lite v2.6.0
+│   │       │   │   │   │   │   │   ├── fastrand v2.3.0
+│   │       │   │   │   │   │   │   ├── futures-core v0.3.31
+│   │       │   │   │   │   │   │   ├── futures-io v0.3.31
+│   │       │   │   │   │   │   │   ├── parking v2.2.1
+│   │       │   │   │   │   │   │   └── pin-project-lite v0.2.16
+│   │       │   │   │   │   │   └── slab v0.4.9
+│   │       │   │   │   │   │       [build-dependencies]
+│   │       │   │   │   │   │       └── autocfg v1.4.0
+│   │       │   │   │   │   ├── async-task v4.7.1
+│   │       │   │   │   │   ├── atomic-waker v1.1.2
+│   │       │   │   │   │   ├── bevy_platform v0.17.2 (*)
+│   │       │   │   │   │   ├── concurrent-queue v2.5.0 (*)
+│   │       │   │   │   │   ├── crossbeam-queue v0.3.12
+│   │       │   │   │   │   │   └── crossbeam-utils v0.8.21
+│   │       │   │   │   │   ├── derive_more v2.0.1 (*)
+│   │       │   │   │   │   └── futures-lite v2.6.0 (*)
+│   │       │   │   │   ├── bevy_utils v0.17.2 (*)
+│   │       │   │   │   ├── bitflags v2.9.0
+│   │       │   │   │   │   ├── bytemuck v1.22.0 (*)
+│   │       │   │   │   │   └── serde v1.0.228 (*)
+│   │       │   │   │   ├── bumpalo v3.17.0
+│   │       │   │   │   ├── concurrent-queue v2.5.0 (*)
+│   │       │   │   │   ├── derive_more v2.0.1 (*)
+│   │       │   │   │   ├── fixedbitset v0.5.7
+│   │       │   │   │   ├── indexmap v2.11.4 (*)
+│   │       │   │   │   ├── log v0.4.27
+│   │       │   │   │   ├── nonmax v0.5.5
+│   │       │   │   │   ├── serde v1.0.228 (*)
+│   │       │   │   │   ├── slotmap v1.0.7
+│   │       │   │   │   │   [build-dependencies]
+│   │       │   │   │   │   └── version_check v0.9.5
+│   │       │   │   │   ├── smallvec v1.15.0
+│   │       │   │   │   ├── thiserror v2.0.17 (*)
+│   │       │   │   │   └── variadics_please v1.1.0 (proc-macro) (*)
+│   │       │   │   ├── bevy_platform v0.17.2 (*)
+│   │       │   │   ├── bevy_reflect v0.17.2 (*)
+│   │       │   │   ├── bevy_tasks v0.17.2 (*)
+│   │       │   │   ├── bevy_utils v0.17.2 (*)
+│   │       │   │   ├── cfg-if v1.0.0
+│   │       │   │   ├── ctrlc v3.4.6
+│   │       │   │   │   └── windows-sys v0.59.0
+│   │       │   │   │       └── windows-targets v0.52.6 (*)
+│   │       │   │   ├── downcast-rs v2.0.2
+│   │       │   │   ├── log v0.4.27
+│   │       │   │   ├── thiserror v2.0.17 (*)
+│   │       │   │   └── variadics_please v1.1.0 (proc-macro) (*)
+│   │       │   ├── bevy_derive v0.17.2 (proc-macro) (*)
+│   │       │   ├── bevy_ecs v0.17.2 (*)
+│   │       │   └── bevy_reflect v0.17.2 (*)
+│   │       ├── bevy_animation v0.17.2
+│   │       │   ├── bevy_animation_macros v0.17.2 (proc-macro)
+│   │       │   │   ├── bevy_macro_utils v0.17.2 (*)
+│   │       │   │   ├── quote v1.0.40 (*)
+│   │       │   │   └── syn v2.0.100 (*)
+│   │       │   ├── bevy_app v0.17.2 (*)
+│   │       │   ├── bevy_asset v0.17.2
+│   │       │   │   ├── async-broadcast v0.7.2
+│   │       │   │   │   ├── event-listener v5.4.0 (*)
+│   │       │   │   │   ├── event-listener-strategy v0.5.4 (*)
+│   │       │   │   │   ├── futures-core v0.3.31
+│   │       │   │   │   └── pin-project-lite v0.2.16
+│   │       │   │   ├── async-fs v2.1.2
+│   │       │   │   │   ├── async-lock v3.4.0
+│   │       │   │   │   │   ├── event-listener v5.4.0 (*)
+│   │       │   │   │   │   ├── event-listener-strategy v0.5.4 (*)
+│   │       │   │   │   │   └── pin-project-lite v0.2.16
+│   │       │   │   │   ├── blocking v1.6.1
+│   │       │   │   │   │   ├── async-channel v2.3.1 (*)
+│   │       │   │   │   │   ├── async-task v4.7.1
+│   │       │   │   │   │   ├── futures-io v0.3.31
+│   │       │   │   │   │   ├── futures-lite v2.6.0 (*)
+│   │       │   │   │   │   └── piper v0.2.4
+│   │       │   │   │   │       ├── atomic-waker v1.1.2
+│   │       │   │   │   │       ├── fastrand v2.3.0
+│   │       │   │   │   │       └── futures-io v0.3.31
+│   │       │   │   │   └── futures-lite v2.6.0 (*)
+│   │       │   │   ├── async-lock v3.4.0 (*)
+│   │       │   │   ├── atomicow v1.1.0
+│   │       │   │   ├── bevy_app v0.17.2 (*)
+│   │       │   │   ├── bevy_asset_macros v0.17.2 (proc-macro)
+│   │       │   │   │   ├── bevy_macro_utils v0.17.2 (*)
+│   │       │   │   │   ├── proc-macro2 v1.0.94 (*)
+│   │       │   │   │   ├── quote v1.0.40 (*)
+│   │       │   │   │   └── syn v2.0.100 (*)
+│   │       │   │   ├── bevy_ecs v0.17.2 (*)
+│   │       │   │   ├── bevy_platform v0.17.2 (*)
+│   │       │   │   ├── bevy_reflect v0.17.2 (*)
+│   │       │   │   ├── bevy_tasks v0.17.2 (*)
+│   │       │   │   ├── bevy_utils v0.17.2 (*)
+│   │       │   │   ├── bitflags v2.9.0 (*)
+│   │       │   │   ├── blake3 v1.8.1
+│   │       │   │   │   ├── arrayref v0.3.9
+│   │       │   │   │   ├── arrayvec v0.7.6
+│   │       │   │   │   ├── cfg-if v1.0.0
+│   │       │   │   │   └── constant_time_eq v0.3.1
+│   │       │   │   │   [build-dependencies]
+│   │       │   │   │   └── cc v1.2.18
+│   │       │   │   │       └── shlex v1.3.0
+│   │       │   │   ├── crossbeam-channel v0.5.15
+│   │       │   │   │   └── crossbeam-utils v0.8.21
+│   │       │   │   ├── derive_more v2.0.1 (*)
+│   │       │   │   ├── disqualified v1.0.0
+│   │       │   │   ├── downcast-rs v2.0.2
+│   │       │   │   ├── either v1.15.0
+│   │       │   │   ├── futures-io v0.3.31
+│   │       │   │   ├── futures-lite v2.6.0 (*)
+│   │       │   │   ├── parking_lot v0.12.3
+│   │       │   │   │   ├── lock_api v0.4.12
+│   │       │   │   │   │   └── scopeguard v1.2.0
+│   │       │   │   │   │   [build-dependencies]
+│   │       │   │   │   │   └── autocfg v1.4.0
+│   │       │   │   │   └── parking_lot_core v0.9.10 (*)
+│   │       │   │   ├── ron v0.10.1
+│   │       │   │   │   ├── base64 v0.22.1
+│   │       │   │   │   ├── bitflags v2.9.0 (*)
+│   │       │   │   │   ├── serde v1.0.228 (*)
+│   │       │   │   │   ├── serde_derive v1.0.228 (proc-macro) (*)
+│   │       │   │   │   └── unicode-ident v1.0.18
+│   │       │   │   ├── serde v1.0.228 (*)
+│   │       │   │   ├── stackfuture v0.3.0
+│   │       │   │   ├── thiserror v2.0.17 (*)
+│   │       │   │   ├── tracing v0.1.41
+│   │       │   │   │   ├── pin-project-lite v0.2.16
+│   │       │   │   │   ├── tracing-attributes v0.1.28 (proc-macro)
+│   │       │   │   │   │   ├── proc-macro2 v1.0.94 (*)
+│   │       │   │   │   │   ├── quote v1.0.40 (*)
+│   │       │   │   │   │   └── syn v2.0.100 (*)
+│   │       │   │   │   └── tracing-core v0.1.33
+│   │       │   │   │       └── once_cell v1.21.3
+│   │       │   │   └── uuid v1.18.1 (*)
+│   │       │   ├── bevy_color v0.17.2
+│   │       │   │   ├── bevy_math v0.17.2
+│   │       │   │   │   ├── bevy_reflect v0.17.2 (*)
+│   │       │   │   │   ├── derive_more v2.0.1 (*)
+│   │       │   │   │   ├── glam v0.30.8 (*)
+│   │       │   │   │   ├── itertools v0.14.0
+│   │       │   │   │   │   └── either v1.15.0
+│   │       │   │   │   ├── libm v0.2.11
+│   │       │   │   │   ├── rand v0.9.0 (*)
+│   │       │   │   │   ├── rand_distr v0.5.1
+│   │       │   │   │   │   ├── num-traits v0.2.19
+│   │       │   │   │   │   │   └── libm v0.2.11
+│   │       │   │   │   │   │   [build-dependencies]
+│   │       │   │   │   │   │   └── autocfg v1.4.0
+│   │       │   │   │   │   └── rand v0.9.0 (*)
+│   │       │   │   │   ├── serde v1.0.228 (*)
+│   │       │   │   │   ├── smallvec v1.15.0
+│   │       │   │   │   ├── thiserror v2.0.17 (*)
+│   │       │   │   │   └── variadics_please v1.1.0 (proc-macro) (*)
+│   │       │   │   ├── bevy_reflect v0.17.2 (*)
+│   │       │   │   ├── bytemuck v1.22.0 (*)
+│   │       │   │   ├── derive_more v2.0.1 (*)
+│   │       │   │   ├── encase v0.11.2
+│   │       │   │   │   ├── const_panic v0.2.12
+│   │       │   │   │   ├── encase_derive v0.11.2 (proc-macro)
+│   │       │   │   │   │   └── encase_derive_impl v0.11.2
+│   │       │   │   │   │       ├── proc-macro2 v1.0.94 (*)
+│   │       │   │   │   │       ├── quote v1.0.40 (*)
+│   │       │   │   │   │       └── syn v2.0.100 (*)
+│   │       │   │   │   ├── glam v0.30.8 (*)
+│   │       │   │   │   └── thiserror v2.0.17 (*)
+│   │       │   │   ├── serde v1.0.228 (*)
+│   │       │   │   ├── thiserror v2.0.17 (*)
+│   │       │   │   └── wgpu-types v26.0.0
+│   │       │   │       ├── bitflags v2.9.0 (*)
+│   │       │   │       ├── bytemuck v1.22.0 (*)
+│   │       │   │       ├── log v0.4.27
+│   │       │   │       └── thiserror v2.0.17 (*)
+│   │       │   ├── bevy_derive v0.17.2 (proc-macro) (*)
+│   │       │   ├── bevy_ecs v0.17.2 (*)
+│   │       │   ├── bevy_math v0.17.2 (*)
+│   │       │   ├── bevy_mesh v0.17.2
+│   │       │   │   ├── bevy_app v0.17.2 (*)
+│   │       │   │   ├── bevy_asset v0.17.2 (*)
+│   │       │   │   ├── bevy_derive v0.17.2 (proc-macro) (*)
+│   │       │   │   ├── bevy_ecs v0.17.2 (*)
+│   │       │   │   ├── bevy_image v0.17.2
+│   │       │   │   │   ├── bevy_app v0.17.2 (*)
+│   │       │   │   │   ├── bevy_asset v0.17.2 (*)
+│   │       │   │   │   ├── bevy_color v0.17.2 (*)
+│   │       │   │   │   ├── bevy_ecs v0.17.2 (*)
+│   │       │   │   │   ├── bevy_math v0.17.2 (*)
+│   │       │   │   │   ├── bevy_platform v0.17.2 (*)
+│   │       │   │   │   ├── bevy_reflect v0.17.2 (*)
+│   │       │   │   │   ├── bevy_utils v0.17.2 (*)
+│   │       │   │   │   ├── bitflags v2.9.0 (*)
+│   │       │   │   │   ├── bytemuck v1.22.0 (*)
+│   │       │   │   │   ├── futures-lite v2.6.0 (*)
+│   │       │   │   │   ├── guillotiere v0.6.2
+│   │       │   │   │   │   ├── euclid v0.22.11
+│   │       │   │   │   │   │   └── num-traits v0.2.19 (*)
+│   │       │   │   │   │   └── svg_fmt v0.4.4
+│   │       │   │   │   ├── half v2.7.1
+│   │       │   │   │   │   ├── cfg-if v1.0.0
+│   │       │   │   │   │   ├── num-traits v0.2.19 (*)
+│   │       │   │   │   │   └── zerocopy v0.8.27 (*)
+│   │       │   │   │   ├── image v0.25.6
+│   │       │   │   │   │   ├── bytemuck v1.22.0 (*)
+│   │       │   │   │   │   ├── byteorder-lite v0.1.0
+│   │       │   │   │   │   ├── num-traits v0.2.19 (*)
+│   │       │   │   │   │   └── png v0.17.16
+│   │       │   │   │   │       ├── bitflags v1.3.2
+│   │       │   │   │   │       ├── crc32fast v1.4.2
+│   │       │   │   │   │       │   └── cfg-if v1.0.0
+│   │       │   │   │   │       ├── fdeflate v0.3.7
+│   │       │   │   │   │       │   └── simd-adler32 v0.3.7
+│   │       │   │   │   │       ├── flate2 v1.1.1
+│   │       │   │   │   │       │   ├── crc32fast v1.4.2 (*)
+│   │       │   │   │   │       │   └── miniz_oxide v0.8.8
+│   │       │   │   │   │       │       ├── adler2 v2.0.0
+│   │       │   │   │   │       │       └── simd-adler32 v0.3.7
+│   │       │   │   │   │       └── miniz_oxide v0.8.8 (*)
+│   │       │   │   │   ├── ktx2 v0.4.0
+│   │       │   │   │   │   └── bitflags v2.9.0 (*)
+│   │       │   │   │   ├── rectangle-pack v0.4.2
+│   │       │   │   │   ├── ruzstd v0.8.1
+│   │       │   │   │   │   └── twox-hash v2.1.2
+│   │       │   │   │   ├── serde v1.0.228 (*)
+│   │       │   │   │   ├── thiserror v2.0.17 (*)
+│   │       │   │   │   ├── tracing v0.1.41 (*)
+│   │       │   │   │   └── wgpu-types v26.0.0 (*)
+│   │       │   │   ├── bevy_math v0.17.2 (*)
+│   │       │   │   ├── bevy_mikktspace v0.17.0-dev
+│   │       │   │   ├── bevy_platform v0.17.2 (*)
+│   │       │   │   ├── bevy_reflect v0.17.2 (*)
+│   │       │   │   ├── bevy_transform v0.17.2
+│   │       │   │   │   ├── bevy_app v0.17.2 (*)
+│   │       │   │   │   ├── bevy_ecs v0.17.2 (*)
+│   │       │   │   │   ├── bevy_log v0.17.2
+│   │       │   │   │   │   ├── bevy_app v0.17.2 (*)
+│   │       │   │   │   │   ├── bevy_ecs v0.17.2 (*)
+│   │       │   │   │   │   ├── bevy_platform v0.17.2 (*)
+│   │       │   │   │   │   ├── bevy_utils v0.17.2 (*)
+│   │       │   │   │   │   ├── tracing v0.1.41 (*)
+│   │       │   │   │   │   ├── tracing-log v0.2.0
+│   │       │   │   │   │   │   ├── log v0.4.27
+│   │       │   │   │   │   │   ├── once_cell v1.21.3
+│   │       │   │   │   │   │   └── tracing-core v0.1.33 (*)
+│   │       │   │   │   │   └── tracing-subscriber v0.3.20
+│   │       │   │   │   │       ├── matchers v0.2.0
+│   │       │   │   │   │       │   └── regex-automata v0.4.9
+│   │       │   │   │   │       │       ├── aho-corasick v1.1.3
+│   │       │   │   │   │       │       │   └── memchr v2.7.4
+│   │       │   │   │   │       │       ├── memchr v2.7.4
+│   │       │   │   │   │       │       └── regex-syntax v0.8.5
+│   │       │   │   │   │       ├── nu-ansi-term v0.50.3
+│   │       │   │   │   │       │   └── windows-sys v0.59.0 (*)
+│   │       │   │   │   │       ├── once_cell v1.21.3
+│   │       │   │   │   │       ├── regex-automata v0.4.9 (*)
+│   │       │   │   │   │       ├── sharded-slab v0.1.7
+│   │       │   │   │   │       │   └── lazy_static v1.5.0
+│   │       │   │   │   │       ├── smallvec v1.15.0
+│   │       │   │   │   │       ├── thread_local v1.1.8 (*)
+│   │       │   │   │   │       ├── tracing v0.1.41 (*)
+│   │       │   │   │   │       ├── tracing-core v0.1.33 (*)
+│   │       │   │   │   │       └── tracing-log v0.2.0 (*)
+│   │       │   │   │   ├── bevy_math v0.17.2 (*)
+│   │       │   │   │   ├── bevy_reflect v0.17.2 (*)
+│   │       │   │   │   ├── bevy_tasks v0.17.2 (*)
+│   │       │   │   │   ├── bevy_utils v0.17.2 (*)
+│   │       │   │   │   ├── derive_more v2.0.1 (*)
+│   │       │   │   │   └── thiserror v2.0.17 (*)
+│   │       │   │   ├── bitflags v2.9.0 (*)
+│   │       │   │   ├── bytemuck v1.22.0 (*)
+│   │       │   │   ├── derive_more v2.0.1 (*)
+│   │       │   │   ├── hexasphere v16.0.0
+│   │       │   │   │   ├── constgebra v0.1.4
+│   │       │   │   │   │   └── const_soft_float v0.1.4
+│   │       │   │   │   └── glam v0.30.8 (*)
+│   │       │   │   ├── thiserror v2.0.17 (*)
+│   │       │   │   ├── tracing v0.1.41 (*)
+│   │       │   │   └── wgpu-types v26.0.0 (*)
+│   │       │   ├── bevy_platform v0.17.2 (*)
+│   │       │   ├── bevy_reflect v0.17.2 (*)
+│   │       │   ├── bevy_time v0.17.2
+│   │       │   │   ├── bevy_app v0.17.2 (*)
+│   │       │   │   ├── bevy_ecs v0.17.2 (*)
+│   │       │   │   ├── bevy_platform v0.17.2 (*)
+│   │       │   │   ├── bevy_reflect v0.17.2 (*)
+│   │       │   │   ├── crossbeam-channel v0.5.15 (*)
+│   │       │   │   └── log v0.4.27
+│   │       │   ├── bevy_transform v0.17.2 (*)
+│   │       │   ├── bevy_utils v0.17.2 (*)
+│   │       │   ├── blake3 v1.8.1 (*)
+│   │       │   ├── derive_more v2.0.1 (*)
+│   │       │   ├── downcast-rs v2.0.2
+│   │       │   ├── either v1.15.0
+│   │       │   ├── petgraph v0.8.3 (*)
+│   │       │   ├── ron v0.10.1 (*)
+│   │       │   ├── serde v1.0.228 (*)
+│   │       │   ├── smallvec v1.15.0
+│   │       │   ├── thiserror v2.0.17 (*)
+│   │       │   ├── thread_local v1.1.8 (*)
+│   │       │   ├── tracing v0.1.41 (*)
+│   │       │   └── uuid v1.18.1 (*)
+│   │       ├── bevy_anti_alias v0.17.2
+│   │       │   ├── bevy_app v0.17.2 (*)
+│   │       │   ├── bevy_asset v0.17.2 (*)
+│   │       │   ├── bevy_camera v0.17.2
+│   │       │   │   ├── bevy_app v0.17.2 (*)
+│   │       │   │   ├── bevy_asset v0.17.2 (*)
+│   │       │   │   ├── bevy_color v0.17.2 (*)
+│   │       │   │   ├── bevy_derive v0.17.2 (proc-macro) (*)
+│   │       │   │   ├── bevy_ecs v0.17.2 (*)
+│   │       │   │   ├── bevy_image v0.17.2 (*)
+│   │       │   │   ├── bevy_math v0.17.2 (*)
+│   │       │   │   ├── bevy_mesh v0.17.2 (*)
+│   │       │   │   ├── bevy_reflect v0.17.2 (*)
+│   │       │   │   ├── bevy_transform v0.17.2 (*)
+│   │       │   │   ├── bevy_utils v0.17.2 (*)
+│   │       │   │   ├── bevy_window v0.17.2
+│   │       │   │   │   ├── bevy_app v0.17.2 (*)
+│   │       │   │   │   ├── bevy_asset v0.17.2 (*)
+│   │       │   │   │   ├── bevy_ecs v0.17.2 (*)
+│   │       │   │   │   ├── bevy_image v0.17.2 (*)
+│   │       │   │   │   ├── bevy_input v0.17.2
+│   │       │   │   │   │   ├── bevy_app v0.17.2 (*)
+│   │       │   │   │   │   ├── bevy_ecs v0.17.2 (*)
+│   │       │   │   │   │   ├── bevy_math v0.17.2 (*)
+│   │       │   │   │   │   ├── bevy_platform v0.17.2 (*)
+│   │       │   │   │   │   ├── bevy_reflect v0.17.2 (*)
+│   │       │   │   │   │   ├── derive_more v2.0.1 (*)
+│   │       │   │   │   │   ├── log v0.4.27
+│   │       │   │   │   │   ├── smol_str v0.2.2 (*)
+│   │       │   │   │   │   └── thiserror v2.0.17 (*)
+│   │       │   │   │   ├── bevy_math v0.17.2 (*)
+│   │       │   │   │   ├── bevy_platform v0.17.2 (*)
+│   │       │   │   │   ├── bevy_reflect v0.17.2 (*)
+│   │       │   │   │   ├── log v0.4.27
+│   │       │   │   │   └── raw-window-handle v0.6.2
+│   │       │   │   ├── derive_more v2.0.1 (*)
+│   │       │   │   ├── downcast-rs v2.0.2
+│   │       │   │   ├── serde v1.0.228 (*)
+│   │       │   │   ├── smallvec v1.15.0
+│   │       │   │   ├── thiserror v2.0.17 (*)
+│   │       │   │   └── wgpu-types v26.0.0 (*)
+│   │       │   ├── bevy_core_pipeline v0.17.2
+│   │       │   │   ├── bevy_app v0.17.2 (*)
+│   │       │   │   ├── bevy_asset v0.17.2 (*)
+│   │       │   │   ├── bevy_camera v0.17.2 (*)
+│   │       │   │   ├── bevy_color v0.17.2 (*)
+│   │       │   │   ├── bevy_derive v0.17.2 (proc-macro) (*)
+│   │       │   │   ├── bevy_ecs v0.17.2 (*)
+│   │       │   │   ├── bevy_image v0.17.2 (*)
+│   │       │   │   ├── bevy_math v0.17.2 (*)
+│   │       │   │   ├── bevy_platform v0.17.2 (*)
+│   │       │   │   ├── bevy_reflect v0.17.2 (*)
+│   │       │   │   ├── bevy_render v0.17.2
+│   │       │   │   │   ├── async-channel v2.3.1 (*)
+│   │       │   │   │   ├── bevy_app v0.17.2 (*)
+│   │       │   │   │   ├── bevy_asset v0.17.2 (*)
+│   │       │   │   │   ├── bevy_camera v0.17.2 (*)
+│   │       │   │   │   ├── bevy_color v0.17.2 (*)
+│   │       │   │   │   ├── bevy_derive v0.17.2 (proc-macro) (*)
+│   │       │   │   │   ├── bevy_diagnostic v0.17.2
+│   │       │   │   │   │   ├── atomic-waker v1.1.2
+│   │       │   │   │   │   ├── bevy_app v0.17.2 (*)
+│   │       │   │   │   │   ├── bevy_ecs v0.17.2 (*)
+│   │       │   │   │   │   ├── bevy_platform v0.17.2 (*)
+│   │       │   │   │   │   ├── bevy_tasks v0.17.2 (*)
+│   │       │   │   │   │   ├── bevy_time v0.17.2 (*)
+│   │       │   │   │   │   ├── const-fnv1a-hash v1.1.0
+│   │       │   │   │   │   ├── log v0.4.27
+│   │       │   │   │   │   └── sysinfo v0.37.2
+│   │       │   │   │   │       ├── libc v0.2.177
+│   │       │   │   │   │       ├── memchr v2.7.4
+│   │       │   │   │   │       ├── ntapi v0.4.1
+│   │       │   │   │   │       │   └── winapi v0.3.9
+│   │       │   │   │   │       └── windows v0.61.1
+│   │       │   │   │   │           ├── windows-collections v0.2.0
+│   │       │   │   │   │           │   └── windows-core v0.61.0
+│   │       │   │   │   │           │       ├── windows-implement v0.60.0 (proc-macro)
+│   │       │   │   │   │           │       │   ├── proc-macro2 v1.0.94 (*)
+│   │       │   │   │   │           │       │   ├── quote v1.0.40 (*)
+│   │       │   │   │   │           │       │   └── syn v2.0.100 (*)
+│   │       │   │   │   │           │       ├── windows-interface v0.59.1 (proc-macro)
+│   │       │   │   │   │           │       │   ├── proc-macro2 v1.0.94 (*)
+│   │       │   │   │   │           │       │   ├── quote v1.0.40 (*)
+│   │       │   │   │   │           │       │   └── syn v2.0.100 (*)
+│   │       │   │   │   │           │       ├── windows-link v0.1.1
+│   │       │   │   │   │           │       ├── windows-result v0.3.2
+│   │       │   │   │   │           │       │   └── windows-link v0.1.1
+│   │       │   │   │   │           │       └── windows-strings v0.4.0
+│   │       │   │   │   │           │           └── windows-link v0.1.1
+│   │       │   │   │   │           ├── windows-core v0.61.0 (*)
+│   │       │   │   │   │           ├── windows-future v0.2.0
+│   │       │   │   │   │           │   ├── windows-core v0.61.0 (*)
+│   │       │   │   │   │           │   └── windows-link v0.1.1
+│   │       │   │   │   │           ├── windows-link v0.1.1
+│   │       │   │   │   │           └── windows-numerics v0.2.0
+│   │       │   │   │   │               ├── windows-core v0.61.0 (*)
+│   │       │   │   │   │               └── windows-link v0.1.1
+│   │       │   │   │   ├── bevy_ecs v0.17.2 (*)
+│   │       │   │   │   ├── bevy_encase_derive v0.17.2 (proc-macro)
+│   │       │   │   │   │   ├── bevy_macro_utils v0.17.2 (*)
+│   │       │   │   │   │   └── encase_derive_impl v0.11.2 (*)
+│   │       │   │   │   ├── bevy_image v0.17.2 (*)
+│   │       │   │   │   ├── bevy_math v0.17.2 (*)
+│   │       │   │   │   ├── bevy_mesh v0.17.2 (*)
+│   │       │   │   │   ├── bevy_platform v0.17.2 (*)
+│   │       │   │   │   ├── bevy_reflect v0.17.2 (*)
+│   │       │   │   │   ├── bevy_render_macros v0.17.2 (proc-macro)
+│   │       │   │   │   │   ├── bevy_macro_utils v0.17.2 (*)
+│   │       │   │   │   │   ├── proc-macro2 v1.0.94 (*)
+│   │       │   │   │   │   ├── quote v1.0.40 (*)
+│   │       │   │   │   │   └── syn v2.0.100 (*)
+│   │       │   │   │   ├── bevy_shader v0.17.2
+│   │       │   │   │   │   ├── bevy_asset v0.17.2 (*)
+│   │       │   │   │   │   ├── bevy_platform v0.17.2 (*)
+│   │       │   │   │   │   ├── bevy_reflect v0.17.2 (*)
+│   │       │   │   │   │   ├── naga v26.0.0
+│   │       │   │   │   │   │   ├── arrayvec v0.7.6
+│   │       │   │   │   │   │   ├── bit-set v0.8.0
+│   │       │   │   │   │   │   │   └── bit-vec v0.8.0
+│   │       │   │   │   │   │   ├── bitflags v2.9.0 (*)
+│   │       │   │   │   │   │   ├── cfg-if v1.0.0
+│   │       │   │   │   │   │   ├── codespan-reporting v0.12.0
+│   │       │   │   │   │   │   │   ├── termcolor v1.4.1
+│   │       │   │   │   │   │   │   │   └── winapi-util v0.1.9
+│   │       │   │   │   │   │   │   │       └── windows-sys v0.59.0 (*)
+│   │       │   │   │   │   │   │   └── unicode-width v0.1.14
+│   │       │   │   │   │   │   ├── half v2.7.1 (*)
+│   │       │   │   │   │   │   ├── hashbrown v0.15.2 (*)
+│   │       │   │   │   │   │   ├── hexf-parse v0.2.1
+│   │       │   │   │   │   │   ├── indexmap v2.11.4 (*)
+│   │       │   │   │   │   │   ├── libm v0.2.11
+│   │       │   │   │   │   │   ├── log v0.4.27
+│   │       │   │   │   │   │   ├── num-traits v0.2.19 (*)
+│   │       │   │   │   │   │   ├── once_cell v1.21.3
+│   │       │   │   │   │   │   ├── rustc-hash v1.1.0
+│   │       │   │   │   │   │   ├── spirv v0.3.0+sdk-1.3.268.0
+│   │       │   │   │   │   │   │   └── bitflags v2.9.0 (*)
+│   │       │   │   │   │   │   ├── thiserror v2.0.17 (*)
+│   │       │   │   │   │   │   └── unicode-ident v1.0.18
+│   │       │   │   │   │   │   [build-dependencies]
+│   │       │   │   │   │   │   └── cfg_aliases v0.2.1
+│   │       │   │   │   │   ├── naga_oil v0.19.1
+│   │       │   │   │   │   │   ├── codespan-reporting v0.12.0 (*)
+│   │       │   │   │   │   │   ├── data-encoding v2.8.0
+│   │       │   │   │   │   │   ├── indexmap v2.11.4 (*)
+│   │       │   │   │   │   │   ├── naga v26.0.0 (*)
+│   │       │   │   │   │   │   ├── regex v1.11.1
+│   │       │   │   │   │   │   │   ├── aho-corasick v1.1.3 (*)
+│   │       │   │   │   │   │   │   ├── memchr v2.7.4
+│   │       │   │   │   │   │   │   ├── regex-automata v0.4.9 (*)
+│   │       │   │   │   │   │   │   └── regex-syntax v0.8.5
+│   │       │   │   │   │   │   ├── rustc-hash v1.1.0
+│   │       │   │   │   │   │   ├── thiserror v2.0.17 (*)
+│   │       │   │   │   │   │   ├── tracing v0.1.41 (*)
+│   │       │   │   │   │   │   └── unicode-ident v1.0.18
+│   │       │   │   │   │   ├── serde v1.0.228 (*)
+│   │       │   │   │   │   ├── thiserror v2.0.17 (*)
+│   │       │   │   │   │   ├── tracing v0.1.41 (*)
+│   │       │   │   │   │   └── wgpu-types v26.0.0 (*)
+│   │       │   │   │   ├── bevy_tasks v0.17.2 (*)
+│   │       │   │   │   ├── bevy_time v0.17.2 (*)
+│   │       │   │   │   ├── bevy_transform v0.17.2 (*)
+│   │       │   │   │   ├── bevy_utils v0.17.2 (*)
+│   │       │   │   │   ├── bevy_window v0.17.2 (*)
+│   │       │   │   │   ├── bitflags v2.9.0 (*)
+│   │       │   │   │   ├── bytemuck v1.22.0 (*)
+│   │       │   │   │   ├── derive_more v2.0.1 (*)
+│   │       │   │   │   ├── downcast-rs v2.0.2
+│   │       │   │   │   ├── encase v0.11.2 (*)
+│   │       │   │   │   ├── fixedbitset v0.5.7
+│   │       │   │   │   ├── image v0.25.6 (*)
+│   │       │   │   │   ├── indexmap v2.11.4 (*)
+│   │       │   │   │   ├── naga v26.0.0 (*)
+│   │       │   │   │   ├── nonmax v0.5.5
+│   │       │   │   │   ├── offset-allocator v0.2.0
+│   │       │   │   │   │   ├── log v0.4.27
+│   │       │   │   │   │   └── nonmax v0.5.5
+│   │       │   │   │   ├── smallvec v1.15.0
+│   │       │   │   │   ├── thiserror v2.0.17 (*)
+│   │       │   │   │   ├── tracing v0.1.41 (*)
+│   │       │   │   │   ├── variadics_please v1.1.0 (proc-macro) (*)
+│   │       │   │   │   └── wgpu v26.0.1
+│   │       │   │   │       ├── arrayvec v0.7.6
+│   │       │   │   │       ├── bitflags v2.9.0 (*)
+│   │       │   │   │       ├── cfg-if v1.0.0
+│   │       │   │   │       ├── document-features v0.2.11 (proc-macro)
+│   │       │   │   │       │   └── litrs v0.4.1
+│   │       │   │   │       ├── hashbrown v0.15.2 (*)
+│   │       │   │   │       ├── log v0.4.27
+│   │       │   │   │       ├── naga v26.0.0 (*)
+│   │       │   │   │       ├── profiling v1.0.16
+│   │       │   │   │       ├── raw-window-handle v0.6.2
+│   │       │   │   │       ├── smallvec v1.15.0
+│   │       │   │   │       ├── static_assertions v1.1.0
+│   │       │   │   │       ├── wgpu-core v26.0.1
+│   │       │   │   │       │   ├── arrayvec v0.7.6
+│   │       │   │   │       │   ├── bit-set v0.8.0 (*)
+│   │       │   │   │       │   ├── bit-vec v0.8.0
+│   │       │   │   │       │   ├── bitflags v2.9.0 (*)
+│   │       │   │   │       │   ├── document-features v0.2.11 (proc-macro) (*)
+│   │       │   │   │       │   ├── hashbrown v0.15.2 (*)
+│   │       │   │   │       │   ├── indexmap v2.11.4 (*)
+│   │       │   │   │       │   ├── log v0.4.27
+│   │       │   │   │       │   ├── naga v26.0.0 (*)
+│   │       │   │   │       │   ├── once_cell v1.21.3
+│   │       │   │   │       │   ├── parking_lot v0.12.3 (*)
+│   │       │   │   │       │   ├── profiling v1.0.16
+│   │       │   │   │       │   ├── raw-window-handle v0.6.2
+│   │       │   │   │       │   ├── rustc-hash v1.1.0
+│   │       │   │   │       │   ├── smallvec v1.15.0
+│   │       │   │   │       │   ├── thiserror v2.0.17 (*)
+│   │       │   │   │       │   ├── wgpu-core-deps-windows-linux-android v26.0.0
+│   │       │   │   │       │   │   └── wgpu-hal v26.0.4
+│   │       │   │   │       │   │       ├── arrayvec v0.7.6
+│   │       │   │   │       │   │       ├── ash v0.38.0+1.3.281
+│   │       │   │   │       │   │       │   └── libloading v0.8.6
+│   │       │   │   │       │   │       │       └── windows-targets v0.52.6 (*)
+│   │       │   │   │       │   │       ├── bit-set v0.8.0 (*)
+│   │       │   │   │       │   │       ├── bitflags v2.9.0 (*)
+│   │       │   │   │       │   │       ├── bytemuck v1.22.0 (*)
+│   │       │   │   │       │   │       ├── cfg-if v1.0.0
+│   │       │   │   │       │   │       ├── gpu-alloc v0.6.0
+│   │       │   │   │       │   │       │   ├── bitflags v2.9.0 (*)
+│   │       │   │   │       │   │       │   └── gpu-alloc-types v0.3.0
+│   │       │   │   │       │   │       │       └── bitflags v2.9.0 (*)
+│   │       │   │   │       │   │       ├── gpu-allocator v0.27.0
+│   │       │   │   │       │   │       │   ├── log v0.4.27
+│   │       │   │   │       │   │       │   ├── presser v0.3.1
+│   │       │   │   │       │   │       │   ├── thiserror v1.0.69
+│   │       │   │   │       │   │       │   │   └── thiserror-impl v1.0.69 (proc-macro)
+│   │       │   │   │       │   │       │   │       ├── proc-macro2 v1.0.94 (*)
+│   │       │   │   │       │   │       │   │       ├── quote v1.0.40 (*)
+│   │       │   │   │       │   │       │   │       └── syn v2.0.100 (*)
+│   │       │   │   │       │   │       │   └── windows v0.58.0
+│   │       │   │   │       │   │       │       ├── windows-core v0.58.0
+│   │       │   │   │       │   │       │       │   ├── windows-implement v0.58.0 (proc-macro)
+│   │       │   │   │       │   │       │       │   │   ├── proc-macro2 v1.0.94 (*)
+│   │       │   │   │       │   │       │       │   │   ├── quote v1.0.40 (*)
+│   │       │   │   │       │   │       │       │   │   └── syn v2.0.100 (*)
+│   │       │   │   │       │   │       │       │   ├── windows-interface v0.58.0 (proc-macro)
+│   │       │   │   │       │   │       │       │   │   ├── proc-macro2 v1.0.94 (*)
+│   │       │   │   │       │   │       │       │   │   ├── quote v1.0.40 (*)
+│   │       │   │   │       │   │       │       │   │   └── syn v2.0.100 (*)
+│   │       │   │   │       │   │       │       │   ├── windows-result v0.2.0
+│   │       │   │   │       │   │       │       │   │   └── windows-targets v0.52.6 (*)
+│   │       │   │   │       │   │       │       │   ├── windows-strings v0.1.0
+│   │       │   │   │       │   │       │       │   │   ├── windows-result v0.2.0 (*)
+│   │       │   │   │       │   │       │       │   │   └── windows-targets v0.52.6 (*)
+│   │       │   │   │       │   │       │       │   └── windows-targets v0.52.6 (*)
+│   │       │   │   │       │   │       │       └── windows-targets v0.52.6 (*)
+│   │       │   │   │       │   │       ├── gpu-descriptor v0.3.2
+│   │       │   │   │       │   │       │   ├── bitflags v2.9.0 (*)
+│   │       │   │   │       │   │       │   ├── gpu-descriptor-types v0.2.0
+│   │       │   │   │       │   │       │   │   └── bitflags v2.9.0 (*)
+│   │       │   │   │       │   │       │   └── hashbrown v0.15.2 (*)
+│   │       │   │   │       │   │       ├── hashbrown v0.15.2 (*)
+│   │       │   │   │       │   │       ├── libloading v0.8.6 (*)
+│   │       │   │   │       │   │       ├── log v0.4.27
+│   │       │   │   │       │   │       ├── naga v26.0.0 (*)
+│   │       │   │   │       │   │       ├── ordered-float v5.0.0
+│   │       │   │   │       │   │       │   └── num-traits v0.2.19 (*)
+│   │       │   │   │       │   │       ├── parking_lot v0.12.3 (*)
+│   │       │   │   │       │   │       ├── profiling v1.0.16
+│   │       │   │   │       │   │       ├── range-alloc v0.1.4
+│   │       │   │   │       │   │       ├── raw-window-handle v0.6.2
+│   │       │   │   │       │   │       ├── renderdoc-sys v1.1.0
+│   │       │   │   │       │   │       ├── smallvec v1.15.0
+│   │       │   │   │       │   │       ├── thiserror v2.0.17 (*)
+│   │       │   │   │       │   │       ├── wgpu-types v26.0.0 (*)
+│   │       │   │   │       │   │       ├── windows v0.58.0 (*)
+│   │       │   │   │       │   │       └── windows-core v0.58.0 (*)
+│   │       │   │   │       │   │       [build-dependencies]
+│   │       │   │   │       │   │       └── cfg_aliases v0.2.1
+│   │       │   │   │       │   ├── wgpu-hal v26.0.4 (*)
+│   │       │   │   │       │   └── wgpu-types v26.0.0 (*)
+│   │       │   │   │       │   [build-dependencies]
+│   │       │   │   │       │   └── cfg_aliases v0.2.1
+│   │       │   │   │       ├── wgpu-hal v26.0.4 (*)
+│   │       │   │   │       └── wgpu-types v26.0.0 (*)
+│   │       │   │   │       [build-dependencies]
+│   │       │   │   │       └── cfg_aliases v0.2.1
+│   │       │   │   ├── bevy_shader v0.17.2 (*)
+│   │       │   │   ├── bevy_transform v0.17.2 (*)
+│   │       │   │   ├── bevy_utils v0.17.2 (*)
+│   │       │   │   ├── bevy_window v0.17.2 (*)
+│   │       │   │   ├── bitflags v2.9.0 (*)
+│   │       │   │   ├── nonmax v0.5.5
+│   │       │   │   ├── radsort v0.1.1
+│   │       │   │   ├── smallvec v1.15.0
+│   │       │   │   ├── thiserror v2.0.17 (*)
+│   │       │   │   └── tracing v0.1.41 (*)
+│   │       │   ├── bevy_derive v0.17.2 (proc-macro) (*)
+│   │       │   ├── bevy_diagnostic v0.17.2 (*)
+│   │       │   ├── bevy_ecs v0.17.2 (*)
+│   │       │   ├── bevy_image v0.17.2 (*)
+│   │       │   ├── bevy_math v0.17.2 (*)
+│   │       │   ├── bevy_reflect v0.17.2 (*)
+│   │       │   ├── bevy_render v0.17.2 (*)
+│   │       │   ├── bevy_shader v0.17.2 (*)
+│   │       │   ├── bevy_utils v0.17.2 (*)
+│   │       │   └── tracing v0.1.41 (*)
+│   │       ├── bevy_app v0.17.2 (*)
+│   │       ├── bevy_asset v0.17.2 (*)
+│   │       ├── bevy_audio v0.17.2
+│   │       │   ├── bevy_app v0.17.2 (*)
+│   │       │   ├── bevy_asset v0.17.2 (*)
+│   │       │   ├── bevy_ecs v0.17.2 (*)
+│   │       │   ├── bevy_math v0.17.2 (*)
+│   │       │   ├── bevy_reflect v0.17.2 (*)
+│   │       │   ├── bevy_transform v0.17.2 (*)
+│   │       │   ├── rodio v0.20.1
+│   │       │   │   ├── cpal v0.15.3
+│   │       │   │   │   ├── dasp_sample v0.11.0
+│   │       │   │   │   └── windows v0.54.0
+│   │       │   │   │       ├── windows-core v0.54.0
+│   │       │   │   │       │   ├── windows-result v0.1.2
+│   │       │   │   │       │   │   └── windows-targets v0.52.6 (*)
+│   │       │   │   │       │   └── windows-targets v0.52.6 (*)
+│   │       │   │   │       └── windows-targets v0.52.6 (*)
+│   │       │   │   └── lewton v0.10.2
+│   │       │   │       ├── byteorder v1.5.0
+│   │       │   │       ├── ogg v0.8.0
+│   │       │   │       │   └── byteorder v1.5.0
+│   │       │   │       └── tinyvec v1.9.0
+│   │       │   │           └── tinyvec_macros v0.1.1
+│   │       │   └── tracing v0.1.41 (*)
+│   │       ├── bevy_camera v0.17.2 (*)
+│   │       ├── bevy_color v0.17.2 (*)
+│   │       ├── bevy_core_pipeline v0.17.2 (*)
+│   │       ├── bevy_derive v0.17.2 (proc-macro) (*)
+│   │       ├── bevy_diagnostic v0.17.2 (*)
+│   │       ├── bevy_ecs v0.17.2 (*)
+│   │       ├── bevy_gilrs v0.17.2
+│   │       │   ├── bevy_app v0.17.2 (*)
+│   │       │   ├── bevy_ecs v0.17.2 (*)
+│   │       │   ├── bevy_input v0.17.2 (*)
+│   │       │   ├── bevy_platform v0.17.2 (*)
+│   │       │   ├── bevy_time v0.17.2 (*)
+│   │       │   ├── gilrs v0.11.0
+│   │       │   │   ├── fnv v1.0.7
+│   │       │   │   ├── gilrs-core v0.6.4
+│   │       │   │   │   ├── log v0.4.27
+│   │       │   │   │   ├── uuid v1.18.1 (*)
+│   │       │   │   │   └── windows v0.61.1 (*)
+│   │       │   │   ├── log v0.4.27
+│   │       │   │   ├── uuid v1.18.1 (*)
+│   │       │   │   └── vec_map v0.8.2
+│   │       │   ├── thiserror v2.0.17 (*)
+│   │       │   └── tracing v0.1.41 (*)
+│   │       ├── bevy_gizmos v0.17.2
+│   │       │   ├── bevy_app v0.17.2 (*)
+│   │       │   ├── bevy_asset v0.17.2 (*)
+│   │       │   ├── bevy_camera v0.17.2 (*)
+│   │       │   ├── bevy_color v0.17.2 (*)
+│   │       │   ├── bevy_core_pipeline v0.17.2 (*)
+│   │       │   ├── bevy_ecs v0.17.2 (*)
+│   │       │   ├── bevy_gizmos_macros v0.17.2 (proc-macro)
+│   │       │   │   ├── bevy_macro_utils v0.17.2 (*)
+│   │       │   │   ├── quote v1.0.40 (*)
+│   │       │   │   └── syn v2.0.100 (*)
+│   │       │   ├── bevy_image v0.17.2 (*)
+│   │       │   ├── bevy_light v0.17.2
+│   │       │   │   ├── bevy_app v0.17.2 (*)
+│   │       │   │   ├── bevy_asset v0.17.2 (*)
+│   │       │   │   ├── bevy_camera v0.17.2 (*)
+│   │       │   │   ├── bevy_color v0.17.2 (*)
+│   │       │   │   ├── bevy_ecs v0.17.2 (*)
+│   │       │   │   ├── bevy_image v0.17.2 (*)
+│   │       │   │   ├── bevy_math v0.17.2 (*)
+│   │       │   │   ├── bevy_mesh v0.17.2 (*)
+│   │       │   │   ├── bevy_platform v0.17.2 (*)
+│   │       │   │   ├── bevy_reflect v0.17.2 (*)
+│   │       │   │   ├── bevy_transform v0.17.2 (*)
+│   │       │   │   ├── bevy_utils v0.17.2 (*)
+│   │       │   │   └── tracing v0.1.41 (*)
+│   │       │   ├── bevy_math v0.17.2 (*)
+│   │       │   ├── bevy_mesh v0.17.2 (*)
+│   │       │   ├── bevy_pbr v0.17.2
+│   │       │   │   ├── bevy_app v0.17.2 (*)
+│   │       │   │   ├── bevy_asset v0.17.2 (*)
+│   │       │   │   ├── bevy_camera v0.17.2 (*)
+│   │       │   │   ├── bevy_color v0.17.2 (*)
+│   │       │   │   ├── bevy_core_pipeline v0.17.2 (*)
+│   │       │   │   ├── bevy_derive v0.17.2 (proc-macro) (*)
+│   │       │   │   ├── bevy_diagnostic v0.17.2 (*)
+│   │       │   │   ├── bevy_ecs v0.17.2 (*)
+│   │       │   │   ├── bevy_image v0.17.2 (*)
+│   │       │   │   ├── bevy_light v0.17.2 (*)
+│   │       │   │   ├── bevy_math v0.17.2 (*)
+│   │       │   │   ├── bevy_mesh v0.17.2 (*)
+│   │       │   │   ├── bevy_platform v0.17.2 (*)
+│   │       │   │   ├── bevy_reflect v0.17.2 (*)
+│   │       │   │   ├── bevy_render v0.17.2 (*)
+│   │       │   │   ├── bevy_shader v0.17.2 (*)
+│   │       │   │   ├── bevy_transform v0.17.2 (*)
+│   │       │   │   ├── bevy_utils v0.17.2 (*)
+│   │       │   │   ├── bitflags v2.9.0 (*)
+│   │       │   │   ├── bytemuck v1.22.0 (*)
+│   │       │   │   ├── derive_more v2.0.1 (*)
+│   │       │   │   ├── fixedbitset v0.5.7
+│   │       │   │   ├── nonmax v0.5.5
+│   │       │   │   ├── offset-allocator v0.2.0 (*)
+│   │       │   │   ├── smallvec v1.15.0
+│   │       │   │   ├── static_assertions v1.1.0
+│   │       │   │   ├── thiserror v2.0.17 (*)
+│   │       │   │   └── tracing v0.1.41 (*)
+│   │       │   ├── bevy_reflect v0.17.2 (*)
+│   │       │   ├── bevy_render v0.17.2 (*)
+│   │       │   ├── bevy_shader v0.17.2 (*)
+│   │       │   ├── bevy_sprite_render v0.17.2
+│   │       │   │   ├── bevy_app v0.17.2 (*)
+│   │       │   │   ├── bevy_asset v0.17.2 (*)
+│   │       │   │   ├── bevy_camera v0.17.2 (*)
+│   │       │   │   ├── bevy_color v0.17.2 (*)
+│   │       │   │   ├── bevy_core_pipeline v0.17.2 (*)
+│   │       │   │   ├── bevy_derive v0.17.2 (proc-macro) (*)
+│   │       │   │   ├── bevy_ecs v0.17.2 (*)
+│   │       │   │   ├── bevy_image v0.17.2 (*)
+│   │       │   │   ├── bevy_math v0.17.2 (*)
+│   │       │   │   ├── bevy_mesh v0.17.2 (*)
+│   │       │   │   ├── bevy_platform v0.17.2 (*)
+│   │       │   │   ├── bevy_reflect v0.17.2 (*)
+│   │       │   │   ├── bevy_render v0.17.2 (*)
+│   │       │   │   ├── bevy_shader v0.17.2 (*)
+│   │       │   │   ├── bevy_sprite v0.17.2
+│   │       │   │   │   ├── bevy_app v0.17.2 (*)
+│   │       │   │   │   ├── bevy_asset v0.17.2 (*)
+│   │       │   │   │   ├── bevy_camera v0.17.2 (*)
+│   │       │   │   │   ├── bevy_color v0.17.2 (*)
+│   │       │   │   │   ├── bevy_derive v0.17.2 (proc-macro) (*)
+│   │       │   │   │   ├── bevy_ecs v0.17.2 (*)
+│   │       │   │   │   ├── bevy_image v0.17.2 (*)
+│   │       │   │   │   ├── bevy_math v0.17.2 (*)
+│   │       │   │   │   ├── bevy_mesh v0.17.2 (*)
+│   │       │   │   │   ├── bevy_picking v0.17.2
+│   │       │   │   │   │   ├── bevy_app v0.17.2 (*)
+│   │       │   │   │   │   ├── bevy_asset v0.17.2 (*)
+│   │       │   │   │   │   ├── bevy_camera v0.17.2 (*)
+│   │       │   │   │   │   ├── bevy_derive v0.17.2 (proc-macro) (*)
+│   │       │   │   │   │   ├── bevy_ecs v0.17.2 (*)
+│   │       │   │   │   │   ├── bevy_input v0.17.2 (*)
+│   │       │   │   │   │   ├── bevy_math v0.17.2 (*)
+│   │       │   │   │   │   ├── bevy_mesh v0.17.2 (*)
+│   │       │   │   │   │   ├── bevy_platform v0.17.2 (*)
+│   │       │   │   │   │   ├── bevy_reflect v0.17.2 (*)
+│   │       │   │   │   │   ├── bevy_time v0.17.2 (*)
+│   │       │   │   │   │   ├── bevy_transform v0.17.2 (*)
+│   │       │   │   │   │   ├── bevy_window v0.17.2 (*)
+│   │       │   │   │   │   ├── crossbeam-channel v0.5.15 (*)
+│   │       │   │   │   │   ├── tracing v0.1.41 (*)
+│   │       │   │   │   │   └── uuid v1.18.1 (*)
+│   │       │   │   │   ├── bevy_reflect v0.17.2 (*)
+│   │       │   │   │   ├── bevy_text v0.17.2
+│   │       │   │   │   │   ├── bevy_app v0.17.2 (*)
+│   │       │   │   │   │   ├── bevy_asset v0.17.2 (*)
+│   │       │   │   │   │   ├── bevy_color v0.17.2 (*)
+│   │       │   │   │   │   ├── bevy_derive v0.17.2 (proc-macro) (*)
+│   │       │   │   │   │   ├── bevy_ecs v0.17.2 (*)
+│   │       │   │   │   │   ├── bevy_image v0.17.2 (*)
+│   │       │   │   │   │   ├── bevy_log v0.17.2 (*)
+│   │       │   │   │   │   ├── bevy_math v0.17.2 (*)
+│   │       │   │   │   │   ├── bevy_platform v0.17.2 (*)
+│   │       │   │   │   │   ├── bevy_reflect v0.17.2 (*)
+│   │       │   │   │   │   ├── bevy_utils v0.17.2 (*)
+│   │       │   │   │   │   ├── cosmic-text v0.14.2
+│   │       │   │   │   │   │   ├── bitflags v2.9.0 (*)
+│   │       │   │   │   │   │   ├── fontdb v0.16.2
+│   │       │   │   │   │   │   │   ├── log v0.4.27
+│   │       │   │   │   │   │   │   ├── memmap2 v0.9.5
+│   │       │   │   │   │   │   │   ├── slotmap v1.0.7 (*)
+│   │       │   │   │   │   │   │   ├── tinyvec v1.9.0 (*)
+│   │       │   │   │   │   │   │   └── ttf-parser v0.20.0
+│   │       │   │   │   │   │   ├── log v0.4.27
+│   │       │   │   │   │   │   ├── rangemap v1.5.1
+│   │       │   │   │   │   │   ├── rustc-hash v1.1.0
+│   │       │   │   │   │   │   ├── rustybuzz v0.14.1
+│   │       │   │   │   │   │   │   ├── bitflags v2.9.0 (*)
+│   │       │   │   │   │   │   │   ├── bytemuck v1.22.0 (*)
+│   │       │   │   │   │   │   │   ├── libm v0.2.11
+│   │       │   │   │   │   │   │   ├── smallvec v1.15.0
+│   │       │   │   │   │   │   │   ├── ttf-parser v0.21.1
+│   │       │   │   │   │   │   │   ├── unicode-bidi-mirroring v0.2.0
+│   │       │   │   │   │   │   │   ├── unicode-ccc v0.2.0
+│   │       │   │   │   │   │   │   ├── unicode-properties v0.1.3
+│   │       │   │   │   │   │   │   └── unicode-script v0.5.7
+│   │       │   │   │   │   │   ├── self_cell v1.1.0
+│   │       │   │   │   │   │   ├── smol_str v0.2.2 (*)
+│   │       │   │   │   │   │   ├── swash v0.2.6
+│   │       │   │   │   │   │   │   ├── skrifa v0.37.0
+│   │       │   │   │   │   │   │   │   ├── bytemuck v1.22.0 (*)
+│   │       │   │   │   │   │   │   │   └── read-fonts v0.35.0
+│   │       │   │   │   │   │   │   │       ├── bytemuck v1.22.0 (*)
+│   │       │   │   │   │   │   │   │       └── font-types v0.10.0
+│   │       │   │   │   │   │   │   │           └── bytemuck v1.22.0 (*)
+│   │       │   │   │   │   │   │   ├── yazi v0.2.1
+│   │       │   │   │   │   │   │   └── zeno v0.3.3
+│   │       │   │   │   │   │   ├── sys-locale v0.3.2
+│   │       │   │   │   │   │   ├── ttf-parser v0.21.1
+│   │       │   │   │   │   │   ├── unicode-bidi v0.3.18
+│   │       │   │   │   │   │   ├── unicode-linebreak v0.1.5
+│   │       │   │   │   │   │   ├── unicode-script v0.5.7
+│   │       │   │   │   │   │   └── unicode-segmentation v1.12.0
+│   │       │   │   │   │   ├── serde v1.0.228 (*)
+│   │       │   │   │   │   ├── smallvec v1.15.0
+│   │       │   │   │   │   ├── sys-locale v0.3.2
+│   │       │   │   │   │   ├── thiserror v2.0.17 (*)
+│   │       │   │   │   │   ├── tracing v0.1.41 (*)
+│   │       │   │   │   │   └── wgpu-types v26.0.0 (*)
+│   │       │   │   │   ├── bevy_transform v0.17.2 (*)
+│   │       │   │   │   ├── bevy_window v0.17.2 (*)
+│   │       │   │   │   ├── radsort v0.1.1
+│   │       │   │   │   ├── tracing v0.1.41 (*)
+│   │       │   │   │   └── wgpu-types v26.0.0 (*)
+│   │       │   │   ├── bevy_text v0.17.2 (*)
+│   │       │   │   ├── bevy_transform v0.17.2 (*)
+│   │       │   │   ├── bevy_utils v0.17.2 (*)
+│   │       │   │   ├── bitflags v2.9.0 (*)
+│   │       │   │   ├── bytemuck v1.22.0 (*)
+│   │       │   │   ├── derive_more v2.0.1 (*)
+│   │       │   │   ├── fixedbitset v0.5.7
+│   │       │   │   ├── nonmax v0.5.5
+│   │       │   │   └── tracing v0.1.41 (*)
+│   │       │   ├── bevy_time v0.17.2 (*)
+│   │       │   ├── bevy_transform v0.17.2 (*)
+│   │       │   ├── bevy_utils v0.17.2 (*)
+│   │       │   ├── bytemuck v1.22.0 (*)
+│   │       │   └── tracing v0.1.41 (*)
+│   │       ├── bevy_gltf v0.17.2
+│   │       │   ├── base64 v0.22.1
+│   │       │   ├── bevy_animation v0.17.2 (*)
+│   │       │   ├── bevy_app v0.17.2 (*)
+│   │       │   ├── bevy_asset v0.17.2 (*)
+│   │       │   ├── bevy_camera v0.17.2 (*)
+│   │       │   ├── bevy_color v0.17.2 (*)
+│   │       │   ├── bevy_ecs v0.17.2 (*)
+│   │       │   ├── bevy_image v0.17.2 (*)
+│   │       │   ├── bevy_light v0.17.2 (*)
+│   │       │   ├── bevy_math v0.17.2 (*)
+│   │       │   ├── bevy_mesh v0.17.2 (*)
+│   │       │   ├── bevy_pbr v0.17.2 (*)
+│   │       │   ├── bevy_platform v0.17.2 (*)
+│   │       │   ├── bevy_reflect v0.17.2 (*)
+│   │       │   ├── bevy_render v0.17.2 (*)
+│   │       │   ├── bevy_scene v0.17.2
+│   │       │   │   ├── bevy_app v0.17.2 (*)
+│   │       │   │   ├── bevy_asset v0.17.2 (*)
+│   │       │   │   ├── bevy_camera v0.17.2 (*)
+│   │       │   │   ├── bevy_derive v0.17.2 (proc-macro) (*)
+│   │       │   │   ├── bevy_ecs v0.17.2 (*)
+│   │       │   │   ├── bevy_platform v0.17.2 (*)
+│   │       │   │   ├── bevy_reflect v0.17.2 (*)
+│   │       │   │   ├── bevy_transform v0.17.2 (*)
+│   │       │   │   ├── bevy_utils v0.17.2 (*)
+│   │       │   │   ├── derive_more v2.0.1 (*)
+│   │       │   │   ├── serde v1.0.228 (*)
+│   │       │   │   ├── thiserror v2.0.17 (*)
+│   │       │   │   └── uuid v1.18.1 (*)
+│   │       │   ├── bevy_tasks v0.17.2 (*)
+│   │       │   ├── bevy_transform v0.17.2 (*)
+│   │       │   ├── fixedbitset v0.5.7
+│   │       │   ├── gltf v1.4.1
+│   │       │   │   ├── byteorder v1.5.0
+│   │       │   │   ├── gltf-json v1.4.1
+│   │       │   │   │   ├── gltf-derive v1.4.1 (proc-macro)
+│   │       │   │   │   │   ├── inflections v1.1.1
+│   │       │   │   │   │   ├── proc-macro2 v1.0.94 (*)
+│   │       │   │   │   │   ├── quote v1.0.40 (*)
+│   │       │   │   │   │   └── syn v2.0.100 (*)
+│   │       │   │   │   ├── serde v1.0.228 (*)
+│   │       │   │   │   ├── serde_derive v1.0.228 (proc-macro) (*)
+│   │       │   │   │   └── serde_json v1.0.140
+│   │       │   │   │       ├── itoa v1.0.15
+│   │       │   │   │       ├── memchr v2.7.4
+│   │       │   │   │       ├── ryu v1.0.20
+│   │       │   │   │       └── serde v1.0.228 (*)
+│   │       │   │   ├── lazy_static v1.5.0
+│   │       │   │   └── serde_json v1.0.140 (*)
+│   │       │   ├── itertools v0.14.0 (*)
+│   │       │   ├── percent-encoding v2.3.1
+│   │       │   ├── serde v1.0.228 (*)
+│   │       │   ├── serde_json v1.0.140 (*)
+│   │       │   ├── smallvec v1.15.0
+│   │       │   ├── thiserror v2.0.17 (*)
+│   │       │   └── tracing v0.1.41 (*)
+│   │       ├── bevy_image v0.17.2 (*)
+│   │       ├── bevy_input v0.17.2 (*)
+│   │       ├── bevy_input_focus v0.17.2
+│   │       │   ├── bevy_app v0.17.2 (*)
+│   │       │   ├── bevy_ecs v0.17.2 (*)
+│   │       │   ├── bevy_input v0.17.2 (*)
+│   │       │   ├── bevy_math v0.17.2 (*)
+│   │       │   ├── bevy_picking v0.17.2 (*)
+│   │       │   ├── bevy_reflect v0.17.2 (*)
+│   │       │   ├── bevy_window v0.17.2 (*)
+│   │       │   ├── log v0.4.27
+│   │       │   └── thiserror v2.0.17 (*)
+│   │       ├── bevy_light v0.17.2 (*)
+│   │       ├── bevy_log v0.17.2 (*)
+│   │       ├── bevy_math v0.17.2 (*)
+│   │       ├── bevy_mesh v0.17.2 (*)
+│   │       ├── bevy_pbr v0.17.2 (*)
+│   │       ├── bevy_picking v0.17.2 (*)
+│   │       ├── bevy_platform v0.17.2 (*)
+│   │       ├── bevy_post_process v0.17.2
+│   │       │   ├── bevy_app v0.17.2 (*)
+│   │       │   ├── bevy_asset v0.17.2 (*)
+│   │       │   ├── bevy_camera v0.17.2 (*)
+│   │       │   ├── bevy_color v0.17.2 (*)
+│   │       │   ├── bevy_core_pipeline v0.17.2 (*)
+│   │       │   ├── bevy_derive v0.17.2 (proc-macro) (*)
+│   │       │   ├── bevy_ecs v0.17.2 (*)
+│   │       │   ├── bevy_image v0.17.2 (*)
+│   │       │   ├── bevy_math v0.17.2 (*)
+│   │       │   ├── bevy_platform v0.17.2 (*)
+│   │       │   ├── bevy_reflect v0.17.2 (*)
+│   │       │   ├── bevy_render v0.17.2 (*)
+│   │       │   ├── bevy_shader v0.17.2 (*)
+│   │       │   ├── bevy_transform v0.17.2 (*)
+│   │       │   ├── bevy_utils v0.17.2 (*)
+│   │       │   ├── bevy_window v0.17.2 (*)
+│   │       │   ├── bitflags v2.9.0 (*)
+│   │       │   ├── nonmax v0.5.5
+│   │       │   ├── radsort v0.1.1
+│   │       │   ├── smallvec v1.15.0
+│   │       │   ├── thiserror v2.0.17 (*)
+│   │       │   └── tracing v0.1.41 (*)
+│   │       ├── bevy_ptr v0.17.2
+│   │       ├── bevy_reflect v0.17.2 (*)
+│   │       ├── bevy_render v0.17.2 (*)
+│   │       ├── bevy_scene v0.17.2 (*)
+│   │       ├── bevy_shader v0.17.2 (*)
+│   │       ├── bevy_sprite v0.17.2 (*)
+│   │       ├── bevy_sprite_render v0.17.2 (*)
+│   │       ├── bevy_state v0.17.2
+│   │       │   ├── bevy_app v0.17.2 (*)
+│   │       │   ├── bevy_ecs v0.17.2 (*)
+│   │       │   ├── bevy_platform v0.17.2 (*)
+│   │       │   ├── bevy_reflect v0.17.2 (*)
+│   │       │   ├── bevy_state_macros v0.17.2 (proc-macro)
+│   │       │   │   ├── bevy_macro_utils v0.17.2 (*)
+│   │       │   │   ├── quote v1.0.40 (*)
+│   │       │   │   └── syn v2.0.100 (*)
+│   │       │   ├── bevy_utils v0.17.2 (*)
+│   │       │   ├── log v0.4.27
+│   │       │   └── variadics_please v1.1.0 (proc-macro) (*)
+│   │       ├── bevy_tasks v0.17.2 (*)
+│   │       ├── bevy_text v0.17.2 (*)
+│   │       ├── bevy_time v0.17.2 (*)
+│   │       ├── bevy_transform v0.17.2 (*)
+│   │       ├── bevy_ui v0.17.2
+│   │       │   ├── accesskit v0.21.1
+│   │       │   ├── bevy_a11y v0.17.2 (*)
+│   │       │   ├── bevy_app v0.17.2 (*)
+│   │       │   ├── bevy_asset v0.17.2 (*)
+│   │       │   ├── bevy_camera v0.17.2 (*)
+│   │       │   ├── bevy_color v0.17.2 (*)
+│   │       │   ├── bevy_derive v0.17.2 (proc-macro) (*)
+│   │       │   ├── bevy_ecs v0.17.2 (*)
+│   │       │   ├── bevy_image v0.17.2 (*)
+│   │       │   ├── bevy_input v0.17.2 (*)
+│   │       │   ├── bevy_math v0.17.2 (*)
+│   │       │   ├── bevy_picking v0.17.2 (*)
+│   │       │   ├── bevy_platform v0.17.2 (*)
+│   │       │   ├── bevy_reflect v0.17.2 (*)
+│   │       │   ├── bevy_sprite v0.17.2 (*)
+│   │       │   ├── bevy_text v0.17.2 (*)
+│   │       │   ├── bevy_transform v0.17.2 (*)
+│   │       │   ├── bevy_utils v0.17.2 (*)
+│   │       │   ├── bevy_window v0.17.2 (*)
+│   │       │   ├── derive_more v2.0.1 (*)
+│   │       │   ├── smallvec v1.15.0
+│   │       │   ├── taffy v0.7.7
+│   │       │   │   ├── arrayvec v0.7.6
+│   │       │   │   ├── grid v0.15.0
+│   │       │   │   └── slotmap v1.0.7 (*)
+│   │       │   ├── thiserror v2.0.17 (*)
+│   │       │   ├── tracing v0.1.41 (*)
+│   │       │   └── uuid v1.18.1 (*)
+│   │       ├── bevy_ui_render v0.17.2
+│   │       │   ├── bevy_app v0.17.2 (*)
+│   │       │   ├── bevy_asset v0.17.2 (*)
+│   │       │   ├── bevy_camera v0.17.2 (*)
+│   │       │   ├── bevy_color v0.17.2 (*)
+│   │       │   ├── bevy_core_pipeline v0.17.2 (*)
+│   │       │   ├── bevy_derive v0.17.2 (proc-macro) (*)
+│   │       │   ├── bevy_ecs v0.17.2 (*)
+│   │       │   ├── bevy_image v0.17.2 (*)
+│   │       │   ├── bevy_math v0.17.2 (*)
+│   │       │   ├── bevy_mesh v0.17.2 (*)
+│   │       │   ├── bevy_platform v0.17.2 (*)
+│   │       │   ├── bevy_reflect v0.17.2 (*)
+│   │       │   ├── bevy_render v0.17.2 (*)
+│   │       │   ├── bevy_shader v0.17.2 (*)
+│   │       │   ├── bevy_sprite v0.17.2 (*)
+│   │       │   ├── bevy_sprite_render v0.17.2 (*)
+│   │       │   ├── bevy_text v0.17.2 (*)
+│   │       │   ├── bevy_transform v0.17.2 (*)
+│   │       │   ├── bevy_ui v0.17.2 (*)
+│   │       │   ├── bevy_utils v0.17.2 (*)
+│   │       │   ├── bytemuck v1.22.0 (*)
+│   │       │   ├── derive_more v2.0.1 (*)
+│   │       │   └── tracing v0.1.41 (*)
+│   │       ├── bevy_utils v0.17.2 (*)
+│   │       ├── bevy_window v0.17.2 (*)
+│   │       └── bevy_winit v0.17.2
+│   │           ├── accesskit v0.21.1
+│   │           ├── accesskit_winit v0.29.1
+│   │           │   ├── accesskit v0.21.1
+│   │           │   ├── accesskit_windows v0.29.1
+│   │           │   │   ├── accesskit v0.21.1
+│   │           │   │   ├── accesskit_consumer v0.30.1
+│   │           │   │   │   ├── accesskit v0.21.1
+│   │           │   │   │   └── hashbrown v0.15.2 (*)
+│   │           │   │   ├── hashbrown v0.15.2 (*)
+│   │           │   │   ├── static_assertions v1.1.0
+│   │           │   │   ├── windows v0.61.1 (*)
+│   │           │   │   └── windows-core v0.61.0 (*)
+│   │           │   ├── raw-window-handle v0.6.2
+│   │           │   └── winit v0.30.9
+│   │           │       ├── bitflags v2.9.0 (*)
+│   │           │       ├── cursor-icon v1.1.0
+│   │           │       ├── dpi v0.1.1
+│   │           │       ├── raw-window-handle v0.6.2
+│   │           │       ├── smol_str v0.2.2 (*)
+│   │           │       ├── tracing v0.1.41 (*)
+│   │           │       ├── unicode-segmentation v1.12.0
+│   │           │       └── windows-sys v0.52.0
+│   │           │           └── windows-targets v0.52.6 (*)
+│   │           │       [build-dependencies]
+│   │           │       └── cfg_aliases v0.2.1
+│   │           ├── approx v0.5.1
+│   │           │   └── num-traits v0.2.19 (*)
+│   │           ├── bevy_a11y v0.17.2 (*)
+│   │           ├── bevy_app v0.17.2 (*)
+│   │           ├── bevy_asset v0.17.2 (*)
+│   │           ├── bevy_derive v0.17.2 (proc-macro) (*)
+│   │           ├── bevy_ecs v0.17.2 (*)
+│   │           ├── bevy_image v0.17.2 (*)
+│   │           ├── bevy_input v0.17.2 (*)
+│   │           ├── bevy_input_focus v0.17.2 (*)
+│   │           ├── bevy_log v0.17.2 (*)
+│   │           ├── bevy_math v0.17.2 (*)
+│   │           ├── bevy_platform v0.17.2 (*)
+│   │           ├── bevy_reflect v0.17.2 (*)
+│   │           ├── bevy_tasks v0.17.2 (*)
+│   │           ├── bevy_window v0.17.2 (*)
+│   │           ├── bytemuck v1.22.0 (*)
+│   │           ├── cfg-if v1.0.0
+│   │           ├── tracing v0.1.41 (*)
+│   │           ├── wgpu-types v26.0.0 (*)
+│   │           └── winit v0.30.9 (*)
+│   └── bevy_internal v0.17.2 (*)
+├── energy v0.1.0 (C:\Users\mathi\Documents\GitHub\LP\crates\energy)
+│   ├── bevy v0.17.2 (*)
+│   └── utils v0.1.0 (C:\Users\mathi\Documents\GitHub\LP\crates\utils)
+│       └── bevy v0.17.2 (*)
+├── forces v0.1.0 (C:\Users\mathi\Documents\GitHub\LP\crates\forces)
+│   └── bevy v0.17.2 (*)
+├── glam v0.29.3
+├── information v0.1.0 (C:\Users\mathi\Documents\GitHub\LP\crates\information)
+│   ├── bevy v0.17.2 (*)
+│   ├── serde v1.0.228 (*)
+│   └── serde_json v1.0.140 (*)
+├── matter v0.1.0 (C:\Users\mathi\Documents\GitHub\LP\crates\matter)
+│   └── bevy v0.17.2 (*)
+├── rand v0.9.0 (*)
+├── serde v1.0.228 (*)
+├── serde_json v1.0.140 (*)
+├── systems v0.1.0 (C:\Users\mathi\Documents\GitHub\LP\crates\systems)
+│   ├── acoustics v0.1.0 (C:\Users\mathi\Documents\GitHub\LP\crates\systems\acoustics)
+│   │   └── bevy v0.17.2 (*)
+│   ├── ai v0.1.0 (C:\Users\mathi\Documents\GitHub\LP\crates\systems\ai)
+│   │   ├── bevy v0.17.2 (*)
+│   │   ├── energy v0.1.0 (C:\Users\mathi\Documents\GitHub\LP\crates\energy) (*)
+│   │   └── rand v0.9.0 (*)
+│   ├── bevy v0.17.2 (*)
+│   ├── mpm v0.1.0 (C:\Users\mathi\Documents\GitHub\LP\crates\systems\mpm)
+│   │   └── bevy v0.17.2 (*)
+│   └── save_system v0.1.0 (C:\Users\mathi\Documents\GitHub\LP\crates\systems\save_system)
+│       ├── bevy v0.17.2 (*)
+│       ├── platform-dirs v0.3.0
+│       │   └── dirs-next v1.0.2
+│       │       ├── cfg-if v1.0.0
+│       │       └── dirs-sys-next v0.1.2
+│       │           └── winapi v0.3.9
+│       ├── serde v1.0.228 (*)
+│       └── serde_json v1.0.140 (*)
+└── utils v0.1.0 (C:\Users\mathi\Documents\GitHub\LP\crates\utils) (*)


### PR DESCRIPTION
## Objective

Migrate the entire LP workspace from Bevy 0.17 to Bevy 0.18.

## Implementation

Updated all 11 Cargo.toml files across the workspace.

## Testing

- cargo check --all passed successfully